### PR TITLE
Set trimTrailingWhitespace in VSCode settings

### DIFF
--- a/quickinstall.sh
+++ b/quickinstall.sh
@@ -553,6 +553,13 @@ EOF
                 sed -i 's/\(.*\)}/\l    \"C_Cpp.clang_format_fallbackStyle\": \"Google\",\n}/' ${SETTINGSPATH} || \
                     { echo "Could not edit ${SETTINGSPATH}."; exit 1; }
             fi
+            # edit files.trimTrailingWhitespace to avoid formatting issues
+            if grep files.trimTrailingWhitespace ${SETTINGSPATH} > /dev/null 2>&1; then
+                sed -i '/files.trimTrailingWhitespace/c\    \"files.trimTrailingWhitespace\": true,' ${SETTINGSPATH}
+            else
+                sed -i 's/}/    \"files.trimTrailingWhitespace\": true,\n}/' ${SETTINGSPATH} || \
+                    { echo "Could not edit ${SETTINGSPATH}."; exit 1; }
+            fi
         else
             echo "from scratch"
             mkdir -p $(dirname ${SETTINGSPATH})


### PR DESCRIPTION
Hi Michael,

As I said in my email, I think turning this setting on for all students is a good idea so that they don't run into issues with this in the lab. I know that there's value in them diagnosing their formatting issues but this setting should really be on by default. This issue caused significant confusion in the lab I visited today, and I think it's more useful for the students to spend that effort focusing on the lab itself.

I tested this by running the updated version of quickinstall.sh locally and the setting was correctly added to the settings.json file. I copied the format from your script so I think it should work as intended, but please take a look and test it yourself before merging (if you agree with the premise). I'm definitely not a bash expert!

Spencer